### PR TITLE
Fix: ignore updown init when updown.io is not used

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -54,6 +54,7 @@ jobs:
           tool: ${{ github.event.inputs.tool }}
         # to create missing entries in updown.io
       - id: updown-init
+        if: ${{ matrix.sites.tools.updownio }}
         uses: "SocialGouv/dashlord-actions/updown-init@v1"
         env:
           UPDOWNIO_API_KEY: ${{ secrets.UPDOWNIO_API_KEY }}


### PR DESCRIPTION
Si updown n'est pas utilisé (`updownio: false`), le updown-init est quand meme executé, cherche la variable d'env `UPDOWNIO_API_KEY`, qu'il ne trouve pas et lance une erreur.
Cf https://github.com/incubateur-territoires/dashlord/actions/runs/7888650896