### PR TITLE
ci: migrate set-output to $GITHUB_OUTPUT and bump checkout/cache to v5

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -46,7 +46,7 @@ jobs:
       sites: ${{ steps.init.outputs.sites }}
       config: ${{ steps.init.outputs.config }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: init
         uses: "SocialGouv/dashlord-actions/init@v1"
         with:
@@ -69,14 +69,14 @@ jobs:
       matrix:
         sites: ${{ fromJson(needs.init.outputs.sites) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
       - run: |
           mkdir scans
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -239,7 +239,7 @@ jobs:
         id: hostname
         run: |
           HOSTNAME=$(echo "${{ matrix.sites.url }}" | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/')
-          echo "::set-output name=value::$HOSTNAME"
+          echo "value=$HOSTNAME" >> "$GITHUB_OUTPUT"
 
       - name: testssl.sh scan
         if: ${{ matrix.sites.tools.testssl }}


### PR DESCRIPTION
## Contexte

Deux correctifs de maintenance CI repérés en exploitant un fork de ce template.

## Changements

- **`::set-output` → `$GITHUB_OUTPUT`** (`scans.yml`, étape *Extract hostname*). La commande `::set-output` est dépréciée depuis 2022 et a cessé de fonctionner avec le retrait de Node 16 des runners. On bascule sur le fichier d'environnement `$GITHUB_OUTPUT`.
- **`actions/checkout@v4` → `@v5`** (×2 dans `scans.yml`, ×1 dans `report.yml`) et **`actions/cache@v4` → `@v5`** (×1 chacun). Anticipe la bascule forcée vers Node 24, la ligne `v4` reposant sur Node 20 (déprécié).

Aucun changement de comportement attendu : ce sont des montées de version mineures d'actions officielles et une migration d'API d'output iso-fonctionnelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)